### PR TITLE
[#11737] new method to fix the way of find submitters

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -66,12 +66,7 @@ public final class FeedbackResponsesLogic {
      * Gets a set of giver identifiers that has at least one response under a feedback session.
      */
     public Set<String> getGiverSetThatAnswerFeedbackSession(String courseId, String feedbackSessionName) {
-        Set<String> giverSet = frDb.getGiverSetThatAnswerFeedbackSession(courseId, feedbackSessionName);
-        List<String> instructorSet = instructorsLogic.getInstructorEmailsForCourse(courseId);
-        if (!fqLogic.sessionHasQuestionsForGiverType(feedbackSessionName, courseId, FeedbackParticipantType.INSTRUCTORS)) {
-            giverSet.addAll(instructorSet);
-        }
-        return giverSet;
+        return frDb.getGiverSetThatAnswerFeedbackSession(courseId, feedbackSessionName);
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionRemindEmailWorkerAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionRemindEmailWorkerAction.java
@@ -35,7 +35,9 @@ class FeedbackSessionRemindEmailWorkerAction extends AdminOnlyAction {
             ).collect(Collectors.toList());
 
             List<InstructorAttributes> instructorsToRemindList = instructorList.stream().filter(instructor ->
-                    !logic.isFeedbackSessionAttemptedByInstructor(session, instructor.getEmail())
+                    !logic.isFeedbackSessionAttemptedByInstructor(session, instructor.getEmail())&&
+                            !(logic.getFeedbackQuestionsForInstructors(session.getFeedbackSessionName(),
+                                    session.getCourseId(),instructor.getEmail()).isEmpty())
             ).collect(Collectors.toList());
 
             List<EmailWrapper> emails = emailGenerator.generateFeedbackSessionReminderEmails(

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionRemindParticularUsersEmailWorkerAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionRemindParticularUsersEmailWorkerAction.java
@@ -39,25 +39,14 @@ class FeedbackSessionRemindParticularUsersEmailWorkerAction extends AdminOnlyAct
                     : null;
 
             for (String userEmail : usersToRemind) {
+                StudentAttributes student = logic.getStudentForEmail(courseId, userEmail);
+                if (student != null) {
+                    studentsToRemindList.add(student);
+                }
 
                 InstructorAttributes instructor = logic.getInstructorForEmail(courseId, userEmail);
                 if (instructor != null) {
                     instructorsToRemindList.add(instructor);
-                }
-
-                StudentAttributes student = logic.getStudentForEmail(courseId, userEmail);
-
-                if (student != null) {
-                    boolean notInstructor = true;
-                    for (InstructorAttributes ins : instructorsToRemindList) {
-                        if (ins.getGoogleId().equals(student.getGoogleId())) {
-                            notInstructor = false;
-                            break;
-                        }
-                    }
-                    if (notInstructor) {
-                        studentsToRemindList.add(student);
-                    }
                 }
 
             }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -5,6 +5,8 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
 import teammates.ui.output.FeedbackSessionSubmittedGiverSet;
 
+import java.util.List;
+
 /**
  * Get a set of givers that has given at least one response in the feedback session.
  */
@@ -35,6 +37,12 @@ class GetFeedbackSessionSubmittedGiverSetAction extends Action {
         FeedbackSessionSubmittedGiverSet output =
                 new FeedbackSessionSubmittedGiverSet(
                         logic.getGiverSetThatAnswerFeedbackSession(courseId, feedbackSessionName));
+        List<InstructorAttributes> instructors = logic.getInstructorsForCourse(courseId);
+        for (InstructorAttributes instructor : instructors){
+            if (logic.getFeedbackQuestionsForInstructors(feedbackSessionName,courseId,instructor.getEmail()).isEmpty()){
+                output.getGiverIdentifiers().add(instructor.getEmail());
+            }
+        }
 
         return new JsonResult(output);
     }


### PR DESCRIPTION
Fixes #11737 

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
Logic problem I find
Instructors' submitted status is "No" when there is no question for them since the logic of getting non-submitters is that: getting set of students and instructors for a certain sessions, then getting a set of givers who submitted at least one question. The students and instructors who are not in the set of givers will be non-submitters.
How I solve it
I changed the way of finding submitters set. Since your logic of non-submitters is the one who is outside the givers set and those who have zero question in a session will be submitters, so those instructors are considered as givers. Then their submitted status will be "Yes".
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
